### PR TITLE
Switch to new naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
 # do-foundations
 Foundations for DigitalOcean-based services
 
-This repository defines a `foundation` service whose purpose is to provide the necessary interfaces to seamlessly deploy other services to DigitalOcean.
+This repository defines a `do-foundations` service whose purpose is to provide the necessary interfaces to seamlessly deploy other services to DigitalOcean.
 
-In particular, an `<environment>` instance of `foundation` provides:
+In particular, an `<environment>` instance of `do-foundations` provides:
 
-- A `<environment>-foundation-terraform` DigitalOcean Spaces Object Storage bucket for Terraform state.
+- A `do-foundations-<environment>-terraform` DigitalOcean Spaces Object Storage bucket for Terraform state.
 
 ## Deployment
+
+### Automatic deployment
 
 The service is continuously deployed by GitHub Actions.
 
 ### Manual deployment
+
+Prefer to make changes via PR and continuous deployment, but manual deployment is possible if necessary.
 
 #### Prerequisites
 
@@ -59,3 +63,10 @@ The service is continuously deployed by GitHub Actions.
    ```sh
    ./deploy.sh '<env>'
    ```
+
+You can alternatively use the `terraform-env.sh` script to set up environment variables for working directly with Terraform:
+
+```sh
+eval "$(./terraform-env.sh do-foundations '<env>')"
+terraform ...
+```

--- a/terraform-env.sh
+++ b/terraform-env.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function usage {
+  echo "Usage: $0 <service> <env>" >&2
+  exit 1
+}
+
+[[ $# -ge 1 ]] || usage
+service="$1"
+shift
+
+[[ $# -ge 1 ]] || usage
+environment="$1"
+shift
+
+
+stateBucket="$service-$environment-terraform"
+stateKey="$service/$environment.tfstate"
+
+tfCliArgs=(
+  '-input=false'
+)
+
+tfCliArgsInit=(
+  ${tfCliArgs[@]}
+  "-backend-config=region=${AWS_REGION:-"$(aws configure get region)"}"
+  "-backend-config=bucket=$stateBucket"
+  "-backend-config=key=$stateKey"
+  '-lockfile=readonly'
+  '-reconfigure'
+)
+
+tfCliArgsPlan=(
+  ${tfCliArgs[@]}
+)
+
+tfCliArgsApply=(
+  ${tfCliArgsPlan[@]}
+  '-auto-approve'
+)
+
+echo "export TF_CLI_ARGS_init='${tfCliArgsInit[@]}'"
+echo "export TF_CLI_ARGS_plan='${tfCliArgsPlan[@]}'"
+echo "export TF_CLI_ARGS_apply='${tfCliArgsApply[@]}'"
+echo "stateBucket=$stateBucket"


### PR DESCRIPTION
- 9ca2b97 **fix: switch to new naming convention**

  This also separates the terraform environment logic from `deploy.sh` to
  make it easier to work with terraform locally (e.g. to tear down
  infrastructure you created with the wrong naming convention...).
